### PR TITLE
Reformat/rewrap comments.

### DIFF
--- a/bootstrap/src/basis/array.ml
+++ b/bootstrap/src/basis/array.ml
@@ -842,8 +842,8 @@ let search_impl ?base ?past key ~cmp mode t =
                     | true ->
                       Some (Cmp.Lt, 0) (* At beginning; key < elms. *)
                     | false ->
-                      Some (Cmp.Gt, (Usize.pred base)) (* In interior;
-                                                          key > predecessor. *)
+                      Some (Cmp.Gt, (Usize.pred base)) (* In interior; key >
+                                                        * predecessor. *)
                   end
                 | Cmp.Eq -> Some (Cmp.Eq, base) (* base at leftmost match. *)
                 | Cmp.Gt -> not_reached ()
@@ -864,8 +864,8 @@ let search_impl ?base ?past key ~cmp mode t =
                 | Cmp.Eq -> Some (Cmp.Eq, probe) (* probe at rightmost match. *)
                 | Cmp.Gt -> begin
                     match (base = (length t)) with
-                    | false -> Some (Cmp.Lt, base) (* In interior;
-                                                      key < successor. *)
+                    | false -> Some (Cmp.Lt, base) (* In interior; key <
+                                                    * successor. *)
                     | true -> Some (Cmp.Gt, probe) (* Past end; key > elms. *)
                   end
               end

--- a/bootstrap/src/basis/array.mli
+++ b/bootstrap/src/basis/array.mli
@@ -110,9 +110,9 @@ val set_inplace: usize -> 'a -> 'a t -> unit
     at index [i] to [elm]. *)
 
 val set: usize -> 'a -> 'a t -> 'a t
-(** Create a new array based on input array, differing in one element.
-    [set i elm t] creates an array equal to [t], except that element [i] is
-    initialized to [elm]. *)
+(** Create a new array based on input array, differing in one element.  [set i
+    elm t] creates an array equal to [t], except that element [i] is initialized
+    to [elm]. *)
 
 val copy: 'a t -> 'a t
 (** Create a copy of an array. *)

--- a/bootstrap/src/basis/bool.mli
+++ b/bootstrap/src/basis/bool.mli
@@ -16,8 +16,8 @@ val to_usize: t -> usize
 val not: t -> t
 (** [not t] returns the logical negation of [t]. *)
 
-(* The && and || operators built in to OCaml are magically short-circuiting.
- * If we define equivalent operators they lose the short-circuiting magic. *)
+(* The && and || operators built in to OCaml are magically short-circuiting.  If
+ * we define equivalent operators they lose the short-circuiting magic. *)
 (*
 val ( && ): t -> t -> t
 val ( || ): t -> t -> t

--- a/bootstrap/src/basis/bytes.mli
+++ b/bootstrap/src/basis/bytes.mli
@@ -1,6 +1,6 @@
-(** Byte array convenience functions.  {!type:string} can represent only
-    well formed UTF-8-encoded {!type:codepoint} sequences, and byte arrays
-    provide a convenient less constrained representation for conversion to/from
+(** Byte array convenience functions.  {!type:string} can represent only well
+    formed UTF-8-encoded {!type:codepoint} sequences, and byte arrays provide a
+    convenient less constrained representation for conversion to/from
     {!type:string}. *)
 
 open Rudiments
@@ -8,16 +8,16 @@ open Rudiments
 include Formattable_intf.S_mono with type t := byte array
 
 val hash_fold: byte array -> Hash.State.t -> Hash.State.t
-(** [hash_fold bytes] incorporates the hash of [bytes] into [state] and
-    returns the resulting state. *)
+(** [hash_fold bytes] incorporates the hash of [bytes] into [state] and returns
+    the resulting state. *)
 
 val of_codepoint: codepoint -> byte array
 (** [of_codepoint codepoint] creates an array of bytes corresponding to the
     UTF-8 encoding of [codepoint]. *)
 
 val of_string: string -> byte array
-(** [of_string string] creates an array of bytes corresponding to the
-    UTF-8 encoding of [string]. *)
+(** [of_string string] creates an array of bytes corresponding to the UTF-8
+    encoding of [string]. *)
 
 val to_string: byte array -> string option
 (** [to_string bytes] interprets [bytes] as a sequence of UTF-8 code points and

--- a/bootstrap/src/basis/cmpable_intf.ml
+++ b/bootstrap/src/basis/cmpable_intf.ml
@@ -103,8 +103,8 @@ module type Key = sig
   include I_mono with type t := t
 end
 
-(** Functor input interface for comparable polymorphic types, e.g. ['a
-    array]. *)
+(** Functor input interface for comparable polymorphic types, e.g. ['a array].
+*)
 module type I_poly = sig
   type 'a t
 

--- a/bootstrap/src/basis/cmper.mli
+++ b/bootstrap/src/basis/cmper.mli
@@ -69,8 +69,8 @@ module type I_poly = sig
       and [pp_a].  [pp_a] is the pretty printer for {!type:'a}. *)
 end
 
-(** Functor output signature for polymorphic comparator types, e.g.
-    {!type:'a list}. *)
+(** Functor output signature for polymorphic comparator types, e.g. {!type:'a
+    list}. *)
 module type S_poly = sig
   type 'a t
   (** Container type. *)
@@ -86,7 +86,7 @@ end
     resulting module contains a comparator that can be used in conjunction with
     e.g. {!type:OrdMap}.  The comparator witness assures that multi-container
     operations can only be performed on containers with compatible comparison
-    functions.  This functor is unusual in that it creates a monomorphic
-    wrapper around a specific actualization of a polymorphic type, so that
-    comparators are always in effect monomorphic. *)
+    functions.  This functor is unusual in that it creates a monomorphic wrapper
+    around a specific actualization of a polymorphic type, so that comparators
+    are always in effect monomorphic. *)
 module Make_poly (T : I_poly) : S_poly with type 'a t := 'a T.t

--- a/bootstrap/src/basis/container_array_intf.ml
+++ b/bootstrap/src/basis/container_array_intf.ml
@@ -43,8 +43,8 @@ module type S_poly_array = sig
   (** Container type. *)
 
   val to_array: 'a t -> 'a array
-  (** [to_array t] converts the elements of [t] from left to right, to an
-      array. *)
+  (** [to_array t] converts the elements of [t] from left to right, to an array.
+  *)
 end
 
 (** {!module:S_poly_array_gen} is equivalent to {!module:S_poly_array}, except
@@ -74,8 +74,8 @@ module type S_poly2_array = sig
   (** Container type. *)
 
   val to_array: ('a, 'cmp) t -> 'a array
-  (** [to_array t] converts the elements of [t] from left to right, to an
-      array. *)
+  (** [to_array t] converts the elements of [t] from left to right, to an array.
+  *)
 end
 
 (** {!module:S_poly2_array_gen} is equivalent to {!module:S_poly2_array}, except
@@ -105,8 +105,8 @@ module type S_poly3_array = sig
   (** Container type. *)
 
   val to_array: ('k, 'v, 'cmp) t -> ('k * 'v) array
-  (** [to_array t] converts the elements of [t] from left to right, to an
-      array. *)
+  (** [to_array t] converts the elements of [t] from left to right, to an array.
+  *)
 end
 
 (** {!module:S_poly3_array_gen} is equivalent to {!module:S_poly3_array}, except

--- a/bootstrap/src/basis/container_common_intf.ml
+++ b/bootstrap/src/basis/container_common_intf.ml
@@ -52,8 +52,8 @@ module type S_mono_fold = sig
     -> 'accum
   (** [fold_right_until ~init ~f t] folds [t] from right to left, using [init]
       as the initial accumulator value, continuing until [f] returns [accum,
-      true], or until folding is complete if [f] always returns [accum,
-      false]. *)
+      true], or until folding is complete if [f] always returns [accum, false].
+  *)
 
   val foldi_until: init:'accum -> f:(usize -> 'accum -> elm -> 'accum * bool)
     -> t -> 'accum
@@ -145,8 +145,8 @@ module type S_mono_mem = sig
   (** Element type. *)
 
   val mem: elm -> t -> bool
-  (** [mem elm t] returns [true] if [elm] is a member of [t]; [false]
-      otherwise. *)
+  (** [mem elm t] returns [true] if [elm] is a member of [t]; [false] otherwise.
+  *)
 end
 
 (* Polymorphic container, e.g. ('a list). *)
@@ -206,8 +206,8 @@ module type S_poly_fold = sig
     -> 'accum
   (** [fold_right_until ~init ~f t] folds [t] from right to left, using [init]
       as the initial accumulator value, continuing until [f] returns [accum,
-      true], or until folding is complete if [f] always returns [accum,
-      false]. *)
+      true], or until folding is complete if [f] always returns [accum, false].
+  *)
 
   val foldi_until: init:'accum -> f:(usize -> 'accum -> 'a -> 'accum * bool)
     -> 'a t -> 'accum

--- a/bootstrap/src/basis/deq.ml
+++ b/bootstrap/src/basis/deq.ml
@@ -3,8 +3,9 @@ open Rudiments
 type 'a t =
   usize * 'a Stream.t * 'a Stream.t * usize * 'a Stream.t * 'a Stream.t
 
-(* Increment size for rebuilding; must be either 2 or 3. Reference: Double-ended
-   queues section in Purely Functional Data Structures by Chris Okasaki. *)
+(* Increment size for rebuilding; must be either 2 or 3.  Reference:
+ * Double-ended queues section in Purely Functional Data Structures by Chris
+ * Okasaki. *)
 let c = 2
 
 let empty = (

--- a/bootstrap/src/basis/deq.mli
+++ b/bootstrap/src/basis/deq.mli
@@ -1,8 +1,7 @@
 (** Lazy-evaluated immutable double-ended queue.
 
-    The deq is an immutable double-ended queue container. All operations on deq
-    are amortized via lazy execution and are O(1).
-*)
+    The deq is an immutable double-ended queue container.  All operations on deq
+    are amortized via lazy execution and are O(1). *)
 
 open Rudiments
 

--- a/bootstrap/src/basis/entropy.ml
+++ b/bootstrap/src/basis/entropy.ml
@@ -2,8 +2,8 @@ open Rudiments_int0
 open Rudiments_functions
 
 (* On success this function returns an array of entropy bits, where the total
-   number of bits is rounded up frome the number of bits requested to the
-   nearest multiple of 64. *)
+ * number of bits is rounded up frome the number of bits requested to the
+ * nearest multiple of 64. *)
 external entropy_nbits: usize -> Int64.t array = "hemlock_entropy_nbits"
 
 let get () =

--- a/bootstrap/src/basis/entropy.mli
+++ b/bootstrap/src/basis/entropy.mli
@@ -8,7 +8,7 @@ val get: unit -> u128
 
 val seed: u128
 (** Seed entropy for this execution of the application, set prior to application
-    entry.  The seed is typically initialized using entropy bits provided
-    by the operating system, but it can be explicitly initialized via the
+    entry.  The seed is typically initialized using entropy bits provided by the
+    operating system, but it can be explicitly initialized via the
     [HEMLOCK_ENTROPY] environment variable, which is interpreted as a
     {!type:u128} constant. *)

--- a/bootstrap/src/basis/float.mli
+++ b/bootstrap/src/basis/float.mli
@@ -66,15 +66,15 @@ val mantissa: t -> usize
     0xf_ffff_ffff_ffff\]]. *)
 
 val m2x: t -> t * isize
-(** [m2x t] splits [t] into a normalized fraction [f] and exponent [x], where
-    [t = f*2^x]. *)
+(** [m2x t] splits [t] into a normalized fraction [f] and exponent [x], where [t
+    = f*2^x]. *)
 
 val f2x: p:isize -> t -> t
 (** [f2x ~p t] computes [t*2^~p]. *)
 
 val modf: t -> Parts.t
-(** [modf t] splits decomposes [t] into the fractional value and integral
-    value which sum to [t].  See {!module:Parts} for further detail. *)
+(** [modf t] splits decomposes [t] into the fractional value and integral value
+    which sum to [t].  See {!module:Parts} for further detail. *)
 
 val min_value: t
 (** Minimum representable value. *)
@@ -192,8 +192,8 @@ val lngamma: t -> t
     function \[S14\].  Communications of the ACM 9(9):684. *)
 
 val gamma: t -> t
-(** [gamma t] applies the {{:
-    https://en.wikipedia.org/wiki/Gamma_function} Gamma} function to [t]. *)
+(** [gamma t] applies the {{: https://en.wikipedia.org/wiki/Gamma_function}
+    Gamma} function to [t]. *)
 
 val sqrt: t -> t
 (** Square root. *)
@@ -224,8 +224,8 @@ val atan: t -> t
 (** [atan t] computes the arc tangent of [t] in radians. *)
 
 val atan2: t -> t -> t
-(** [atan2 t0 t1] computes the arc tangent of [t0 / t1], where the signs of
-    [t1] and [t0] determine the quadrant of the result. *)
+(** [atan2 t0 t1] computes the arc tangent of [t0 / t1], where the signs of [t1]
+    and [t0] determine the quadrant of the result. *)
 
 val sinh: t -> t
 (** [sinh t] computes the hyperbolic sine of [t]. *)

--- a/bootstrap/src/basis/hash.ml
+++ b/bootstrap/src/basis/hash.ml
@@ -24,7 +24,7 @@ module State = struct
       (* Number of u128 blocks folded. *)
       nfolded: usize;
       (* The bottom nrem bytes of rem are remainder bytes that have yet to be
-         hashed, and the top pad bytes are always zeroed. *)
+       * hashed, and the top pad bytes are always zeroed. *)
       rem: u128;
       nrem: usize;
     }
@@ -213,7 +213,7 @@ let%expect_test "hash_fold_u128" =
       end
   end in
   (* These test inputs were manually verified against the reference
-     MurmurHash3 implementation. *)
+   * MurmurHash3 implementation. *)
   let u128s_list = [
     [||];
 
@@ -279,7 +279,7 @@ let%expect_test "hash_fold_u8" =
       end
   end in
   (* These test inputs were manually verified against the reference
-     MurmurHash3 implementation. *)
+   * MurmurHash3 implementation. *)
   let u8s_list = [
     [||];
 

--- a/bootstrap/src/basis/hash.mli
+++ b/bootstrap/src/basis/hash.mli
@@ -29,8 +29,8 @@ module State : sig
       state is based on {!Entropy.seed}. *)
 
   (** Decomposed hash state generator API for use in implementing [hash_fold]
-      for types that do not map perfectly to other types.  The hash algorithm
-      is the 128-bit variant of {{: https://en.wikipedia.org/wiki/MurmurHash}
+      for types that do not map perfectly to other types.  The hash algorithm is
+      the 128-bit variant of {{: https://en.wikipedia.org/wiki/MurmurHash}
       MurmurHash3}, which hashes 128-bit blocks with automatic support for a
       partial block during finalization. *)
   module Gen : sig
@@ -48,11 +48,11 @@ module State : sig
         by [~f] into [t] and returns the resulting hash state generator. *)
 
     val fold_u8: usize -> f:(usize -> usize) -> t -> t
-    (** [fold_u8 n ~f t] incorporates the hash of [n] indexed values provided
-        by [~f] into [t] and returns the resulting hash state generator.  Note
-        that the values returned by [~f] are treated as {!type:u8} (only the
-        least significant 8 bits are used), but the exported type signature
-        differs due to bootstrapping constraints. *)
+    (** [fold_u8 n ~f t] incorporates the hash of [n] indexed values provided by
+        [~f] into [t] and returns the resulting hash state generator.  Note that
+        the values returned by [~f] are treated as {!type:u8} (only the least
+        significant 8 bits are used), but the exported type signature differs
+        due to bootstrapping constraints. *)
 
     val fini: t -> outer
     (** [fini t] produces a hash state which is a function of the state provided

--- a/bootstrap/src/basis/i64.ml
+++ b/bootstrap/src/basis/i64.ml
@@ -47,7 +47,7 @@ let to_string t =
 
 let of_float f =
   (* OCaml handles overflow poorly, but this deficiency has no anticipated
-     impact on bootstrapping. *)
+   * impact on bootstrapping. *)
   Int64.of_float f
 
 let to_float t =

--- a/bootstrap/src/basis/intnb.ml
+++ b/bootstrap/src/basis/intnb.ml
@@ -161,7 +161,7 @@ module Make_common (T : I_common) : S_common with type t := usize = struct
 
     let of_float f =
       (* OCaml handles overflow poorly, but this deficiency has no anticipated
-         impact on bootstrapping. *)
+       * impact on bootstrapping. *)
       match T.signed || (f >= 0.) with
       | true -> narrow (int_of_float f)
       | false -> 0

--- a/bootstrap/src/basis/intnb_intf.ml
+++ b/bootstrap/src/basis/intnb_intf.ml
@@ -59,8 +59,8 @@ module type S_derived = sig
       nearest integer, or halts if [t] less than 1. *)
 
   val ceil_lg: t -> t
-  (** [ceil_lg t] returns the base 2 logarithm of [t], rounded up to the
-      nearest integer, or halts if [t] is less than 1. *)
+  (** [ceil_lg t] returns the base 2 logarithm of [t], rounded up to the nearest
+      integer, or halts if [t] is less than 1. *)
 
   val min: t -> t -> t
   (** [min a b] returns the minimum of [a] and [b]. *)
@@ -154,15 +154,15 @@ module type S = sig
   include S_derived with type t := t
 end
 
-(** Functor output signature for narrowing functions.  These functions are
-    only needed by integer types based on the default integer types, and are
-    a bootstrapping artifact. *)
+(** Functor output signature for narrowing functions.  These functions are only
+    needed by integer types based on the default integer types, and are a
+    bootstrapping artifact. *)
 module type S_narrow = sig
   type t
 
   val narrow_of_signed: isize -> t
-  (** Narrow full-width signed integer.  Sign is preserved, but precision may
-      be silently lost. *)
+  (** Narrow full-width signed integer.  Sign is preserved, but precision may be
+      silently lost. *)
 
   val narrow_of_unsigned: usize -> t
   (** Narrow full-width unsigned integer.  Sign is preserved, but precision may

--- a/bootstrap/src/basis/list.mli
+++ b/bootstrap/src/basis/list.mli
@@ -35,8 +35,8 @@ end
 val hash_fold: ('a -> Hash.State.t -> Hash.State.t) -> 'a t -> Hash.State.t
   -> Hash.State.t
 (** [hash_fold hash_fold_a t state] incorporates the hash of [t] into [state]
-    and returns the resulting state.  List elements are sequentially
-    hash-folded into the resulting state via [hash_fold_a]. *)
+    and returns the resulting state.  List elements are sequentially hash-folded
+    into the resulting state via [hash_fold_a]. *)
 
 val cmp: ('a -> 'a -> Cmp.t) -> 'a t -> 'a t -> Cmp.t
 (** Compare two lists using the element comparison function.  The list lengths
@@ -174,14 +174,14 @@ val groupi: break:(usize -> 'a -> 'a -> bool) -> 'a t -> 'a t t
     the given index.  Not tail-recursive. *)
 
 val rev_group: break:('a -> 'a -> bool) -> 'a t -> 'a t t
-(** [rev_group ~break t] is equivalent to
-    [fold (group t ~break) ~init:[] ~f:(fun gs g -> (rev g) :: gs)], except that
-    implementation is tail-recursive. *)
+(** [rev_group ~break t] is equivalent to [fold (group t ~break) ~init:[]
+    ~f:(fun gs g -> (rev g) :: gs)], except that implementation is
+    tail-recursive. *)
 
 val rev_groupi: break:(usize -> 'a -> 'a -> bool) -> 'a t -> 'a t t
-(** [rev_groupi ~break t] is equivalent to
-    [fold (groupi t ~break) ~init:[] ~f:(fun gs g -> (rev g) :: gs)], except
-    that implementation is tail-recursive. *)
+(** [rev_groupi ~break t] is equivalent to [fold (groupi t ~break) ~init:[]
+    ~f:(fun gs g -> (rev g) :: gs)], except that implementation is
+    tail-recursive. *)
 
 (** {1 Re-ordering, mapping, reducing, and filtering} *)
 
@@ -214,9 +214,8 @@ val dedup: ?length:usize -> cmp:('a -> 'a -> Cmp.t) -> 'a t -> 'a t
 
 val rev_dedup: ?length:usize -> cmp:('a -> 'a -> Cmp.t) -> 'a t -> 'a t
 (** Sort list stably, remove subsequent duplicates in forward order, and reverse
-    elements relative to the input.  If specified, [?length] must equal
-    [(length list)].  [rev_dedup t ~cmp] is equivalent to
-    [rev (dedup t ~cmp)]. *)
+    elements relative to the input.  If specified, [?length] must equal [(length
+    list)].  [rev_dedup t ~cmp] is equivalent to [rev (dedup t ~cmp)]. *)
 
 val dedup_sorted: cmp:('a -> 'a -> Cmp.t) -> 'a t -> 'a t
 (** Remove sebsequent adjacent duplicates in forward order. *)
@@ -227,13 +226,13 @@ val rev_dedup_sorted: cmp:('a -> 'a -> Cmp.t) -> 'a t -> 'a t
 
 val merge: cmp:('a -> 'a -> Cmp.t) -> 'a t -> 'a t -> 'a t
 (** Merge sorted input lists into a sorted output list.  For [(merge ~cmp t0
-    t1)], equal elements from [t0] precede those from [t1].  Not
-    tail-recursive. *)
+    t1)], equal elements from [t0] precede those from [t1].  Not tail-recursive.
+*)
 
 val rev_merge: cmp:('a -> 'a -> Cmp.t) -> 'a t -> 'a t -> 'a t
-(** Merge sorted input lists into a reverse-sorted output list.  For
-    [(rev_merge ~cmp t0 t1)], equal elements from [t1] precede those from [t0].
-    [rev_merge ~cmp t0 t1] is equivalent to [rev (merge ~cmp t0 t1)]. *)
+(** Merge sorted input lists into a reverse-sorted output list.  For [(rev_merge
+    ~cmp t0 t1)], equal elements from [t1] precede those from [t0].  [rev_merge
+    ~cmp t0 t1] is equivalent to [rev (merge ~cmp t0 t1)]. *)
 
 val map: f:('a -> 'b) -> 'a t -> 'b t
 (** Create a list with elements mapped from the input list, according to the
@@ -254,7 +253,7 @@ val rev_mapi: f:(usize -> 'a -> 'b) -> 'a t -> 'b t
 val rev_map_concat: f:('a -> 'b) -> 'a t -> 'b t -> 'b t
 (** For [rev_map_concat ~f t0 t1], concatenate the reversed mapping of [t0] with
     [t1].  Equivalent to [rev_concat (map ~f t0) t1], except that the
-    implementation is tail-recursive.  *)
+    implementation is tail-recursive. *)
 
 val fold_map: init:'accum -> f:('accum -> 'a -> 'accum * 'b) -> 'a t
   -> 'accum * 'b t
@@ -328,17 +327,17 @@ val iteri2: f:(usize -> 'a -> 'b -> unit) -> 'a t -> 'b t -> unit
     visiting function in increasing index order. *)
 
 val map2: f:('a -> 'b -> 'c) -> 'a t -> 'b t -> 'c t
-(** Create a list with elements mapped by the element mapping function from
-    the paired elements of two input lists. *)
+(** Create a list with elements mapped by the element mapping function from the
+    paired elements of two input lists. *)
 
 val mapi2: f:(usize -> 'a -> 'b -> 'c) -> 'a t -> 'b t -> 'c t
 (** Create a list with elements mapped by the indexed element mapping function
     from the paired elements of two input lists. *)
 
 val rev_map2: f:('a -> 'b -> 'c) -> 'a t -> 'b t -> 'c t
-(** Create a list with elements mapped by the element mapping function from
-    the paired elements of two input lists, and reverse the elements relative to
-    the input lists' associated order. *)
+(** Create a list with elements mapped by the element mapping function from the
+    paired elements of two input lists, and reverse the elements relative to the
+    input lists' associated order. *)
 
 val rev_mapi2: f:(usize -> 'a -> 'b -> 'c) -> 'a t -> 'b t -> 'c t
 (** Create a list with elements mapped by the indexed element mapping function

--- a/bootstrap/src/basis/map_intf.ml
+++ b/bootstrap/src/basis/map_intf.ml
@@ -61,8 +61,8 @@ module type S = sig
   (** {1 Length} *)
 
   val length: ('k, 'v, 'cmp) t -> usize
-  (** [length t] returns the number of mappings in [t].  O(1) time
-      complexity. *)
+  (** [length t] returns the number of mappings in [t].  O(1) time complexity.
+  *)
 
   val is_empty: ('k, 'v, 'cmp) t -> bool
   (** [is_empty t] returns [true] if [t] has no mappings; [false] otherwise.
@@ -71,8 +71,8 @@ module type S = sig
   (** {1 Mapping operations} *)
 
   val mem: 'k -> ('k, 'v, 'cmp) t -> bool
-  (** [mem k t] returns [true] if [k] is a key in [t]; [false] otherwise.
-      O(lg n) time complexity if ordered, O(1) time complexity if unordered. *)
+  (** [mem k t] returns [true] if [k] is a key in [t]; [false] otherwise.  O(lg
+      n) time complexity if ordered, O(1) time complexity if unordered. *)
 
   val get: 'k -> ('k, 'v, 'cmp) t -> 'v option
   (** [get k t] returns the value [Some v] associated with [k] if [k] is a key
@@ -80,9 +80,9 @@ module type S = sig
       complexity if unordered. *)
 
   val get_hlt: 'k -> ('k, 'v, 'cmp) t -> 'v
-  (** [get_hlt k t] returns the value [v] associated with [k] if [k] is a
-      key in [t], halts otherwise.  O(lg n) time complexity if ordered, O(1)
-      time complexity if unordered. *)
+  (** [get_hlt k t] returns the value [v] associated with [k] if [k] is a key in
+      [t], halts otherwise.  O(lg n) time complexity if ordered, O(1) time
+      complexity if unordered. *)
 
   val choose: ('k, 'v, 'cmp) t -> ('k * 'v) option
   (** [choose t] returns an arbitrary key-value mapping in [t] if the map is
@@ -215,8 +215,8 @@ module type S = sig
       [f] returns [true], or [None] if [f] always returns [false]. *)
 
   val find_map: f:(('k * 'v) -> 'a option) -> ('k, 'v, 'cmp) t -> 'a option
-  (** [find_map ~f t] iterates over [t] and returns [Some a] for a mapping
-      which [f] returns [Some a], or [None] if [f] always returns [None]. *)
+  (** [find_map ~f t] iterates over [t] and returns [Some a] for a mapping which
+      [f] returns [Some a], or [None] if [f] always returns [None]. *)
 
   val filter: f:(('k * 'v) -> bool) -> ('k, 'v, 'cmp) t -> ('k, 'v, 'cmp) t
   (** [filter ~f t] creates a map with contents filtered by [~f].  Only mappings
@@ -240,9 +240,9 @@ module type S = sig
       [First v2] vs [Second v3].  Θ(n) time complexity. *)
 
   val kreduce: f:('k -> 'k -> 'k) -> ('k, 'v, 'cmp) t -> 'k option
-  (** [kreduce ~f t] reduces [t] to a single key, or [None] if the map is
-      empty.  The reduction function is assumed to be associative; thus
-      reduction order is unspecified. *)
+  (** [kreduce ~f t] reduces [t] to a single key, or [None] if the map is empty.
+      The reduction function is assumed to be associative; thus reduction order
+      is unspecified. *)
 
   val kreduce_hlt: f:('k -> 'k -> 'k) -> ('k, 'v, 'cmp) t -> 'k
   (** [kreduce_hlt ~f t] reduces [t] to a single key, or halts if the map is
@@ -353,8 +353,8 @@ module type S_ord = sig
     -> ('k, 'v, 'cmp) t -> 'accum
   (** [fold_right_until ~init ~f t] folds [t] from right to left, using [init]
       as the initial accumulator value, continuing until [f] returns [accum,
-      true], or until folding is complete if [f] always returns [accum,
-      false]. *)
+      true], or until folding is complete if [f] always returns [accum, false].
+  *)
 
   val foldi_until: init:'accum -> f:(usize -> 'accum -> ('k * 'v)
     -> 'accum * bool) -> ('k, 'v, 'cmp) t -> 'accum
@@ -412,19 +412,19 @@ module type S_ord = sig
 
   val min_elm: cmp:(('k * 'v) -> ('k * 'v) -> Cmp.t) -> ('k, 'v, 'cmp) t
     -> ('k * 'v) option
-  (** [min_elm ~f t] iterates from left to right over [t] and returns [Some
-      (k, v)] for the leftmost element which always compares as [Cmp.Lt] or
+  (** [min_elm ~f t] iterates from left to right over [t] and returns [Some (k,
+      v)] for the leftmost element which always compares as [Cmp.Lt] or
       [Cmp.Eq], or [None] if [t] is empty. *)
 
   val max_elm: cmp:(('k * 'v) -> ('k * 'v) -> Cmp.t) -> ('k, 'v, 'cmp) t
     -> ('k * 'v) option
-  (** [max_elm ~f t] iterates from left to right over [t] and returns [Some
-      (k, v)] for the leftmost element which always compares as [Cmp.Eq] or
+  (** [max_elm ~f t] iterates from left to right over [t] and returns [Some (k,
+      v)] for the leftmost element which always compares as [Cmp.Eq] or
       [Cmp.Gt], or [None] if [t] is empty. *)
 
   (** {1 Conversion} *)
 
   val to_alist_rev: ('k, 'v, 'cmp) t -> ('k * 'v) list
-  (** [to_alist_rev t] folds [t] from left to right as a {!type:('k * 'v)
-      list}. *)
+  (** [to_alist_rev t] folds [t] from left to right as a {!type:('k * 'v) list}.
+  *)
 end

--- a/bootstrap/src/basis/option.mli
+++ b/bootstrap/src/basis/option.mli
@@ -83,5 +83,5 @@ val merge: f:('a -> 'a -> 'a) -> 'a t -> 'a t -> 'a t
     a1], otherwise the most preserving of [Some a0], [Some a1], and [None]. *)
 
 val map2: f:('a -> 'b -> 'c) -> 'a t -> 'b t -> 'c t
-(** [map2 ~f t0 t1] returns [Some (f a b)] if [t0 = Some a] and [t1 = Some
-    b], [None] otherwise. *)
+(** [map2 ~f t0 t1] returns [Some (f a b)] if [t0 = Some a] and [t1 = Some b],
+    [None] otherwise. *)

--- a/bootstrap/src/basis/ordset.ml
+++ b/bootstrap/src/basis/ordset.ml
@@ -594,8 +594,8 @@ let%expect_test "fold_until" =
   let test ms = begin
     let ordset = of_list (module Usize) ms in
     (* Compute the number of elements in the triangle defined by folding n
-       times, each time terminating upon encounter of a distinct set member.
-       The size of the triangle is insensitive to fold order. *)
+     * times, each time terminating upon encounter of a distinct set member.
+     * The size of the triangle is insensitive to fold order. *)
     assert ((List.length ms) = (length ordset));
     let n = length ordset in
     let triangle_sum = List.fold ms ~init:0 ~f:(fun accum m ->
@@ -624,8 +624,8 @@ let%expect_test "fold_right_until" =
   let test ms = begin
     let ordset = of_list (module Usize) ms in
     (* Compute the number of elements in the triangle defined by folding n
-       times, each time terminating upon encounter of a distinct set member.
-       The size of the triangle is insensitive to fold order. *)
+     * times, each time terminating upon encounter of a distinct set member.
+     * The size of the triangle is insensitive to fold order. *)
     assert ((List.length ms) = (length ordset));
     let n = length ordset in
     let triangle_sum = List.fold ms ~init:0 ~f:(fun accum m ->
@@ -657,8 +657,8 @@ let%expect_test "fold2_until" =
     let ordset = union ordset0 ordset1 in
     let ms = to_list ordset in
     (* Compute the number of elements in the triangle defined by folding n
-       times, each time terminating upon encounter of a distinct set member.
-       The size of the triangle is insensitive to fold order. *)
+     * times, each time terminating upon encounter of a distinct set member.
+     * The size of the triangle is insensitive to fold order. *)
     assert ((List.length ms) = (length ordset));
     let n = length ordset in
     let triangle_sum = List.fold ms ~init:0 ~f:(fun accum m ->

--- a/bootstrap/src/basis/q.mli
+++ b/bootstrap/src/basis/q.mli
@@ -1,7 +1,7 @@
 (** Lazy-evaluated immutable queue.
 
-     The q is an immutable queue container. All operations on q are amortized
-     via lazy execution and are O(1).
+    The q is an immutable queue container.  All operations on q are amortized
+    via lazy execution and are O(1).
 *)
 
 open Rudiments

--- a/bootstrap/src/basis/result.mli
+++ b/bootstrap/src/basis/result.mli
@@ -65,15 +65,15 @@ val error_ignore_hlt: ('a, _) t list -> unit
 
 val map_ok: f:('a -> 'c) -> ('a, 'b) t -> ('c, 'b) t
 (** [map_ok ~f t] returns [Ok (f a)] if [t = Ok a], or [Error b] if [t = Error
-     b]. *)
+    b]. *)
 
 val map_error: f:('b -> 'c) -> ('a, 'b) t -> ('a, 'c) t
-(** [map_error ~f t] returns [Error (f b)] if [t = Error b], or [Ok a] if [t
-    = Ok a]. *)
+(** [map_error ~f t] returns [Error (f b)] if [t = Error b], or [Ok a] if [t =
+    Ok a]. *)
 
 val merge: ok:('a -> 'a -> 'a) -> error:('b -> 'b -> 'b) -> ('a, 'b) t
   -> ('a, 'b) t -> ('a, 'b) t
 (** [merge ~ok ~error t0 t1] returns [Ok (ok a0 a1)] if [t0 = Ok a0] and [t1 =
-     Ok a1], [Error (error b0 b1)] if [t0 = Error b0] and [t1 = Error b1], or
-     [Error b0] or [Error b1] if [t0 = Error b0] or [t1 = Error b1],
-     respectively. *)
+    Ok a1], [Error (error b0 b1)] if [t0 = Error b0] and [t1 = Error b1], or
+    [Error b0] or [Error b1] if [t0 = Error b0] or [t1 = Error b1],
+    respectively. *)

--- a/bootstrap/src/basis/rudiments_int0.ml
+++ b/bootstrap/src/basis/rudiments_int0.ml
@@ -92,14 +92,14 @@ let u128_add t0 t1 =
 
 let u128_mul t0 t1 =
   (* Decompose inputs into arrays of 32-bit half-words, then use the standard
-     paper method of multi-digit multiplication, but in base 2^32.  The full
-     result requires m + n digits, where m and n are the number of input digits
-     in the muliplier and multiplicand.  For this function, ndigits=m=n=4, and
-     we only calculate/preserve the lowest ndigits digits.
-
-     The digit arrays are encoded as (u32 array), which assures that only
-     significant bits are stored.  The intermediate computations use 64-bit math
-     so that two digits fit. *)
+   * paper method of multi-digit multiplication, but in base 2^32.  The full
+   * result requires m + n digits, where m and n are the number of input digits
+   * in the muliplier and multiplicand.  For this function, ndigits=m=n=4, and
+   * we only calculate/preserve the lowest ndigits digits.
+   *
+   * The digit arrays are encoded as (u32 array), which assures that only
+   * significant bits are stored.  The intermediate computations use 64-bit math
+   * so that two digits fit. *)
   let hi32 x = Int64.shift_right_logical x 32 in
   let lo32 x = Int64.(logand x (of_int 0xffff_ffff)) in
   let digits32 x = hi32 x, lo32 x in

--- a/bootstrap/src/basis/rudiments_int0.mli
+++ b/bootstrap/src/basis/rudiments_int0.mli
@@ -24,8 +24,8 @@ val u128_of_usize: usize -> u128
 
 val u128_pp_x: Format.formatter -> u128 -> unit
 (** [u128_pp_x ppf u] prints a hexadecimal representation of [u] to the pretty
-    printing formatter, [ppf].  This function is intended for use with the
-    [%a] format specifier to {!Format.printf}.*)
+    printing formatter, [ppf].  This function is intended for use with the [%a]
+    format specifier to {!Format.printf}.*)
 
 val u128_zero: u128
 (** Zero constant. *)

--- a/bootstrap/src/basis/seq_intf.ml
+++ b/bootstrap/src/basis/seq_intf.ml
@@ -144,13 +144,12 @@ module type S_poly2_fold2 = sig
   val fold2_until: init:'accum
     -> f:('accum -> 'a elm option -> 'a elm option -> 'accum * bool)
     -> ('a, 'cmp) t -> ('a, 'cmp) t -> 'accum
-  (** [fold2_until ~init ~f t0 t1] folds over the union of [t0] and [t1]
-      from left to right if ordered, or arbitrarily if unordered, and calls
-      [~f accum elm0_opt elm1_opt] once for each element in the union such that
-      if the element is absent from one of the input sets, the corresponding
-      parameter is [None].  Folding terminates early if [~f] returns [(_,
-      true)].  O(m+n) time complexity, where m and n are the input set
-      lengths. *)
+  (** [fold2_until ~init ~f t0 t1] folds over the union of [t0] and [t1] from
+      left to right if ordered, or arbitrarily if unordered, and calls [~f accum
+      elm0_opt elm1_opt] once for each element in the union such that if the
+      element is absent from one of the input sets, the corresponding parameter
+      is [None].  Folding terminates early if [~f] returns [(_, true)].  O(m+n)
+      time complexity, where m and n are the input set lengths. *)
 
   val fold2: init:'accum
     -> f:('accum -> 'a elm option -> 'a elm option -> 'accum) -> ('a, 'cmp) t
@@ -160,7 +159,7 @@ module type S_poly2_fold2 = sig
       elm0_opt elm1_opt] once for each element in the union such that if the
       element is absent from one of the input sets, the corresponding parameter
       is [None].  Θ(m+n) time complexity, where m and n are the input set
-      lengths.  *)
+      lengths. *)
 
   val iter2: f:('a elm option -> 'a elm option -> unit) -> ('a, 'cmp) t ->
     ('a, 'cmp) t -> unit
@@ -228,13 +227,12 @@ module type S_poly3_fold2 = sig
   val fold2_until: init:'accum -> f:('accum -> ('k key * 'v value) option ->
     ('k key * 'v value) option -> 'accum * bool) -> ('k, 'v, 'cmp) t ->
     ('k, 'v, 'cmp) t -> 'accum
-  (** [fold2_until ~init ~f t0 t1] folds over the union of [t0] and [t1]
-      from left to right if ordered, or arbitrarily if unordered, and calls
-      [~f accum elm0_opt elm1_opt] once for each element in the union such that
-      if the element is absent from one of the input sets, the corresponding
-      parameter is [None].  Folding terminates early if [~f] returns [(_,
-      true)].  O(m+n) time complexity, where m and n are the input set
-      lengths. *)
+  (** [fold2_until ~init ~f t0 t1] folds over the union of [t0] and [t1] from
+      left to right if ordered, or arbitrarily if unordered, and calls [~f accum
+      elm0_opt elm1_opt] once for each element in the union such that if the
+      element is absent from one of the input sets, the corresponding parameter
+      is [None].  Folding terminates early if [~f] returns [(_, true)].  O(m+n)
+      time complexity, where m and n are the input set lengths. *)
 
   val fold2: init:'accum -> f:('accum -> ('k key * 'v value) option ->
     ('k key * 'v value) option -> 'accum) -> ('k, 'v, 'cmp) t ->
@@ -244,7 +242,7 @@ module type S_poly3_fold2 = sig
       elm0_opt elm1_opt] once for each element in the union such that if the
       element is absent from one of the input sets, the corresponding parameter
       is [None].  Θ(m+n) time complexity, where m and n are the input set
-      lengths.  *)
+      lengths. *)
 
   val iter2: f:(('k key * 'v value) option -> ('k key * 'v value) option ->
     unit) -> ('k, 'v, 'cmp) t -> ('k, 'v, 'cmp) t -> unit

--- a/bootstrap/src/basis/set.ml
+++ b/bootstrap/src/basis/set.ml
@@ -363,8 +363,8 @@ let%expect_test "fold_until" =
   let test ms = begin
     let set = of_list (module Usize) ms in
     (* Compute the number of elements in the triangle defined by folding n
-       times, each time terminating upon encounter of a distinct set member.
-       The size of the triangle is insensitive to fold order. *)
+     * times, each time terminating upon encounter of a distinct set member.
+     * The size of the triangle is insensitive to fold order. *)
     assert ((List.length ms) = (length set));
     let n = length set in
     let triangle_sum = List.fold ms ~init:0 ~f:(fun accum m ->
@@ -396,8 +396,8 @@ let%expect_test "fold2_until" =
     let set = union set0 set1 in
     let ms = to_list set in
     (* Compute the number of elements in the triangle defined by folding n
-       times, each time terminating upon encounter of a distinct set member.
-       The size of the triangle is insensitive to fold order. *)
+     * times, each time terminating upon encounter of a distinct set member.
+     * The size of the triangle is insensitive to fold order. *)
     assert ((List.length ms) = (length set));
     let n = length set in
     let triangle_sum = List.fold ms ~init:0 ~f:(fun accum m ->

--- a/bootstrap/src/basis/set_intf.ml
+++ b/bootstrap/src/basis/set_intf.ml
@@ -45,8 +45,8 @@ module type S = sig
   (** {1 Length} *)
 
   val length: ('a, 'cmp) t -> usize
-  (** [length t] returns the number of elements in [t].  O(1) time
-      complexity. *)
+  (** [length t] returns the number of elements in [t].  O(1) time complexity.
+  *)
 
   val is_empty: ('a, 'cmp) t -> bool
   (** [is_empty t] returns [true] if [t] has no elements; [false] otherwise.
@@ -91,8 +91,8 @@ module type S = sig
       elements, [false] otherwise.  O(n) time complexity. *)
 
   val union: ('a, 'cmp) t -> ('a, 'cmp) t -> ('a, 'cmp) t
-  (** [union t0 t1] creates a set that is the union of [t0] and [t1]; that is,
-      a set that contains all elements in [t0] or [t1].  O(m lg (n/m + 1)) time
+  (** [union t0 t1] creates a set that is the union of [t0] and [t1]; that is, a
+      set that contains all elements in [t0] or [t1].  O(m lg (n/m + 1)) time
       complexity if ordered, where m and n are the input set lengths and m <= n;
       Θ(m+n) time complexity if unordered. *)
 
@@ -250,8 +250,8 @@ module type S_ord = sig
       are the input set lengths. *)
 
   val split: 'a -> ('a, 'cmp) t -> ('a, 'cmp) t * 'a option * ('a, 'cmp) t
-  (** [split a t] tripartitions [t] into elements \{<,=,>\} [a],
-      respectively. *)
+  (** [split a t] tripartitions [t] into elements \{<,=,>\} [a], respectively.
+  *)
 
   (** {1 Folding, mapping, and filtering} *)
 
@@ -259,8 +259,8 @@ module type S_ord = sig
     -> ('a, 'cmp) t -> 'accum
   (** [fold_right_until ~init ~f t] folds [t] from right to left, using [init]
       as the initial accumulator value, continuing until [f] returns [accum,
-      true], or until folding is complete if [f] always returns [accum,
-      false]. *)
+      true], or until folding is complete if [f] always returns [accum, false].
+  *)
 
   val foldi_until: init:'accum -> f:(usize -> 'accum -> 'a -> 'accum * bool)
     -> ('a, 'cmp) t -> 'accum

--- a/bootstrap/src/basis/sign.mli
+++ b/bootstrap/src/basis/sign.mli
@@ -8,8 +8,8 @@ type t =
 include Formattable_intf.S_mono with type t := t
 
 val of_isize: int -> t
-(** [of_isize x] returns [Neg] if [x < 0], [Zero] if [x = 0], or [Pos] if
-    [x > 0]. *)
+(** [of_isize x] returns [Neg] if [x < 0], [Zero] if [x = 0], or [Pos] if [x >
+    0]. *)
 
 val to_isize: t -> int
 (** [to_isize t] returns [-1], [0], or [1]. *)

--- a/bootstrap/src/basis/stream.ml
+++ b/bootstrap/src/basis/stream.ml
@@ -39,9 +39,9 @@ let tl = function
   | lazy Nil -> halt "Empty stream has no tail"
   | lazy (Cons(_, t)) -> t
 
-(* Non-lazy internal function of push (conventionally named push'). It is
-   exposed outside of push since it is useful within non-lazy sections of other
-   stream functions. *)
+(* Non-lazy internal function of push (conventionally named push').  It is
+ * exposed outside of push since it is useful within non-lazy sections of other
+ * stream functions. *)
 let push' elm s =
   Cons(elm, s)
 

--- a/bootstrap/src/basis/string.ml
+++ b/bootstrap/src/basis/string.ml
@@ -1866,8 +1866,8 @@ let%expect_test "hash_fold" =
         test strs'
       end
   end in
-  (* These test inputs were manually verified against the reference
-     MurmurHash3 implementation. *)
+  (* These test inputs were manually verified against the reference MurmurHash3
+   * implementation. *)
   let strings = [""; "hello"; "hello_goodbye"; "<_>"; "«»"; "‡"; "𐆗"] in
   test strings;
   printf "@]";

--- a/bootstrap/src/basis/string.mli
+++ b/bootstrap/src/basis/string.mli
@@ -21,8 +21,8 @@ type t = string
 include Identifiable_intf.S with type t := t
 include Stringable_intf.S with type t := t
 
-(** Cursor that supports O(1) arbitrary access to codepoints, given byte
-    index.  The codepoint index is not tracked. *)
+(** Cursor that supports O(1) arbitrary access to codepoints, given byte index.
+    The codepoint index is not tracked. *)
 module Cursor : sig
   type outer = t
 
@@ -237,8 +237,7 @@ module Slice : sig
       Knuth-Morris-Pratt algorithm}.  Patterns are uninterpreted codepoint
       sequences.  Searches require at most a single pass over the input,
       regardless of whether finding one or more (optionally overlapping)
-      matches.
-  *)
+      matches. *)
   module Pattern : sig
     type outer = t
 
@@ -327,8 +326,8 @@ module Slice : sig
 
   val split_fold: init:'accum -> on:(codepoint -> bool)
     -> f:('accum -> slice -> 'accum) -> t -> 'accum
-  (** [split_fold ~init ~on ~f t] splits [t] on [on] into slices, which
-      [f] folds in left to right order based on initial value [init]. *)
+  (** [split_fold ~init ~on ~f t] splits [t] on [on] into slices, which [f]
+      folds in left to right order based on initial value [init]. *)
 
   val split_fold_right: init:'accum -> on:(codepoint -> bool)
     -> f:(slice -> 'accum -> 'accum) -> t -> 'accum
@@ -468,8 +467,8 @@ val filter: f:(codepoint -> bool) -> t -> t
     codepoints for which [f] returns [true] are incorporated into the result. *)
 
 val concat: ?sep:t -> t list -> t
-(** [concat ~sep strings] creates a string comprised of the concatenation of
-    the [strings] list, with [sep] interposed between the inputs. *)
+(** [concat ~sep strings] creates a string comprised of the concatenation of the
+    [strings] list, with [sep] interposed between the inputs. *)
 
 val concat_rev: ?sep:t -> t list -> t
 (** [concat_rev ~sep strings] creates a string comprised of the concatenation of
@@ -511,8 +510,8 @@ val rfind: ?base:Cursor.t -> ?past:Cursor.t -> codepoint -> t
     [None] if [cp] is absent. *)
 
 val rfind_hlt: ?base:Cursor.t -> ?past:Cursor.t -> codepoint -> t -> Cursor.t
-(** [rfind_hlt cp t] returns a cursor to the rightmost instance of [cp] in
-    [t], or halts if [cp] is absent. *)
+(** [rfind_hlt cp t] returns a cursor to the rightmost instance of [cp] in [t],
+    or halts if [cp] is absent. *)
 
 val substr_find: ?base:Cursor.t -> pattern:t -> t -> Cursor.t option
 (** [substr_find ~base ~pattern t] returns a cursor to the leftmost [pattern]

--- a/bootstrap/src/basis/u128.ml
+++ b/bootstrap/src/basis/u128.ml
@@ -141,11 +141,11 @@ module T = struct
 
   let div_mod t0 t1 =
     (* Compute quotient and remainder using an algorithm similar to the paper
-       long division algorithm, but in base 2^32.
-
-       The digit arrays are encoded as (u32 array), which assures that only
-       significant bits are stored.  The intermediate computations use 64-bit
-       math so that two digits fit. *)
+     * long division algorithm, but in base 2^32.
+     *
+     * The digit arrays are encoded as (u32 array), which assures that only
+     * significant bits are stored.  The intermediate computations use 64-bit
+     * math so that two digits fit. *)
     let b = U64.(bit_sl ~shift:32 one) in
     (* Extract the high/low digit from a 2-digit value. *)
     let hi32 x = U64.bit_usr ~shift:32 x in
@@ -153,11 +153,11 @@ module T = struct
     let div_b x = Int64.shift_right x 32 in
     let mul_b x = I64.bit_sl ~shift:32 x in
     (* Get/set digit.  Only the low 32 bits are used; if u32 were available it
-       would be a better choice for array elements. *)
+     * would be a better choice for array elements. *)
     let get arr i = U64.to_i64 (U32.to_u64 (Caml.Array.get arr i)) in
     let set arr i x = Caml.Array.set arr i (U32.of_u64 (U64.of_i64 x)) in
     (* Digit array creation and conversion functions.  Digits are in
-       little-endian order (least significant digit at offset 0). *)
+     * little-endian order (least significant digit at offset 0). *)
     let zero_arr ndigits = Caml.Array.make ndigits U32.zero in
     let to_arr u = [|U32.of_u64 (lo32 u.lo); U32.of_u64 (hi32 u.lo);
       U32.of_u64 (lo32 u.hi); U32.of_u64 (hi32 u.hi);|] in
@@ -167,7 +167,7 @@ module T = struct
       {hi; lo}
     end in
     (* Compute the number of significant digits in a digit array, i.e. subtract
-       high-order zeros from the array size. *)
+     * high-order zeros from the array size. *)
     let sig_digits arr = begin
       let rec fn arr past = begin
         match past with
@@ -208,7 +208,7 @@ module T = struct
       end
     | _, false -> begin
         (* Choose normalization power-of-2 multiplier such that the divisor is
-           losslessly shifted left as far as possible. *)
+         * losslessly shifted left as far as possible. *)
         let shift = Rudiments_int.(
           (U64.bit_clz (get v Rudiments_int.(pred n))) - 32) in
         (* Initialize normalized divisor. *)
@@ -236,8 +236,8 @@ module T = struct
         (* Main computation. *)
         let rec fn_j j = begin
           (* Compute quotient digit estimate and remainder.  It is possible that
-             qdigit is one larger than the correct value, in which case
-             subsequent correction code executes. *)
+           * qdigit is one larger than the correct value, in which case
+           * subsequent correction code executes. *)
           let qdigit = begin
             let rec qdigit_converge qdigit rem = begin
               match (U64.(qdigit >= b) ||

--- a/bootstrap/src/basis/utf8.mli
+++ b/bootstrap/src/basis/utf8.mli
@@ -53,5 +53,5 @@ val to_string: t -> string
 (** [to_string t] returns a UTF-8-encoded string representation of [t]. *)
 
 val escape: t -> string
-(** [escape t] returns a syntactically valid UTF-8-encoded string
-    representation of [t]. *)
+(** [escape t] returns a syntactically valid UTF-8-encoded string representation
+    of [t]. *)

--- a/src/basis/array.hl
+++ b/src/basis/array.hl
@@ -777,8 +777,8 @@ let search_impl ?base ?past key ~cmp mode t =
                     | true ->
                       Some (Cmp.Lt, 0) (* At beginning; key < elms. *)
                     | false ->
-                      Some (Cmp.Gt, pred base) (* In interior;
-                                                         key > predecessor. *)
+                      Some (Cmp.Gt, pred base) (* In interior; key >
+                                                * predecessor. *)
                   end
                 | Cmp.Eq -> Some (Cmp.Eq, base) (* base at leftmost match. *)
                 | Cmp.Gt -> not_reached ()
@@ -799,8 +799,8 @@ let search_impl ?base ?past key ~cmp mode t =
                 | Cmp.Eq -> Some (Cmp.Eq, probe) (* probe at rightmost match. *)
                 | Cmp.Gt -> begin
                     match (base = (length t)) with
-                    | false -> Some (Cmp.Lt, base) (* In interior;
-                                                      key < successor. *)
+                    | false -> Some (Cmp.Lt, base) (* In interior; key <
+                                                    * successor. *)
                     | true -> Some (Cmp.Gt, probe) (* Past end; key > elms. *)
                   end
               end
@@ -845,7 +845,7 @@ module Array_foldi_map = struct
       length: usize;
     }
     (* val init: 'a /arr outer -> (usize -> 'accum -> 'a >e-> 'accum * 'b)
-         -> usize -> ('a, /arr, >e) ['accum, 'b] t *)
+     *   -> usize -> ('a, /arr, >e) ['accum, 'b] t *)
     let init arr ~f length =
       {arr; f; length; index=0}
 
@@ -854,7 +854,7 @@ module Array_foldi_map = struct
       t.length
 
     (* val next: ('a, /arr, >e) ['accum, 'b] t
-         >e-> 'a * ('a, /arr, >e) ['accum, 'b] t * 'accum *)
+     *   >e-> 'a * ('a, /arr, >e) ['accum, 'b] t * 'accum *)
     let next t accum =
       let accum', elm' = t.f t.index accum (get t.index t.arr) in
       let t' = {t with index=succ t.index} in
@@ -960,8 +960,8 @@ module Array_foldi2_map = struct
     }
 
     (* val init: 'a /m outer -> 'b /n outer
-         -> f:(usize -> 'accum -> 'a -> 'b -> >e-> 'accum * 'c)
-         -> ('a, /m, 'b, /n, >e) ['accum, 'c] t *)
+     *   -> f:(usize -> 'accum -> 'a -> 'b -> >e-> 'accum * 'c)
+     *   -> ('a, /m, 'b, /n, >e) ['accum, 'c] t *)
     let init arr0 arr1 ~f =
       {arr0; arr1; f; index=0}
 
@@ -970,7 +970,7 @@ module Array_foldi2_map = struct
       length t.arr0
 
     (* val next: ('a, /m, 'b, /n, >e) ['accum, 'c] t -> 'accum
-         -> 'c * ('a, /m, 'b, /n, >e) ['accum, 'c] t * 'accum *)
+     *   -> 'c * ('a, /m, 'b, /n, >e) ['accum, 'c] t * 'accum *)
     let next t accum =
       let accum', elm' =
         t.f t.index accum (get t.index t.arr0) (get t.index t.arr1) in

--- a/src/basis/array.hli
+++ b/src/basis/array.hli
@@ -7,7 +7,7 @@ include Container_common_intf.S_poly_fold with type 'a /t t := 'a /t t
 include Formattable_intf.S_poly with type 'a /t t := 'a /t t
 
 (** Cursor that supports arbitrary array element access.  All operations are
-    O(1). *)
+  * O(1). *)
 module Cursor : sig
   type 'a /c container = 'a /c t
   type 'a /t t


### PR DESCRIPTION
Prefer comment continuation characters where possible.  OCaml's (**...*)
documentation generation system does not strip continuation * characters, so
leave them out of OCaml doc comments.